### PR TITLE
Fix missing comma after nip44_decrypt

### DIFF
--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -102,7 +102,7 @@ export const IMGPROXY_URL = "https://imgproxy.coracle.social"
 export const REACTION_KINDS = [REACTION, ZAP_RESPONSE]
 
 export const NIP46_PERMS =
-  "nip04_encrypt,nip04_decrypt,nip44_encrypt,nip44_decrypt" +
+  "nip04_encrypt,nip04_decrypt,nip44_encrypt,nip44_decrypt," +
   [CLIENT_AUTH, AUTH_JOIN, MESSAGE, THREAD, COMMENT, MEMBERSHIPS, WRAP, REACTION]
     .map(k => `sign_event:${k}`)
     .join(",")


### PR DESCRIPTION
was creating a nostrconnect uri with a missing comma after nip44_decrypt

perms=nip04_encrypt,nip04_decrypt,nip44_encrypt,nip44_decryptsign_event:22242,sign_event:28934,sign_event:209,sign_event:309,sign_event:1111,sign_event:10209,sign_event:1059,sign_event:7&